### PR TITLE
fix(lsp-client): enhance path normalization with acode url transformer

### DIFF
--- a/packages/acode-lsp-client/src/main.js
+++ b/packages/acode-lsp-client/src/main.js
@@ -52,31 +52,62 @@ function normalizePath(path, includeFilePrefix = false, useAcodeUrlTransformer =
   if (!path) return '';
 
   let normalized;
+  
+  // Define base prefixes (lengths derived automatically)
+  // Legacy internal storage ROOT
+  const LEGACY_EMULATED_ROOT = 'file:///storage/emulated/0/';
+  // Android Content External Document ROOT
+  const ANDROID_CONTENT_EXTERNAL_DOC_ROOT = 'content://com.android.externalstorage.documents';
+  const PRIMARY_PREFIX = 'primary:';
+  const CONTENT_TREE_PREFIX = 'content://com.android.externalstorage.documents/tree/primary%3A';
 
   if (useAcodeUrlTransformer) {
+    // Back Off for these Paths
+    if(path === LEGACY_EMULATED_ROOT || path === ANDROID_CONTENT_EXTERNAL_DOC_ROOT) {
+      return normalizePath(path, includeFilePrefix, false)
+    }
+
     const acodeUrl = acode.require('Url');
     if (!acodeUrl) return normalizePath(path, includeFilePrefix, false)
 
     normalized = acodeUrl.pathname(path);
 
-    // Slice off `/` if there's two 🙃 ~ UnschooledGamer
+    // Slice off one `/`, if there's two of them 🙃 ~ UnschooledGamer
     if (normalized.startsWith('//'))
-      return normalized.slice(1);
+      normalized = normalized.slice(1);
 
     return normalized;
   }
-
-  if (path.includes('::')) {
-    const [, raw] = path.split('::');
-    normalized = raw?.startsWith('primary:') ? `/sdcard/${raw.slice('primary:'.length)}` : raw;
-  } else if (path.startsWith('file:///storage/emulated/0/')) {
-    normalized = `/sdcard/${path.slice('file:///storage/emulated/0/'.length)}`;
-  } else {
+  
+  // Handle ContentProvider secondary URI (:: separator)
+  // Gets the path after the separator, where primary means Emulated internal/primary Storage/refered as `/sdcard/`
+  
+  const colonIndex = path.indexOf('::');
+  
+  if (colonIndex !== -1) {
+    const secondaryPath = path.slice(colonIndex + 2);
+    normalized = secondaryPath.startsWith(PRIMARY_PREFIX) 
+      ? `/sdcard/${secondaryPath.slice(PRIMARY_PREFIX.length)}` 
+      : secondaryPath;
+  }
+  // Handle ContentProvider document tree URI 
+  // When there's no secondary path/file related paths
+  else if (path.startsWith(CONTENT_TREE_PREFIX)) {
+      normalized = `/sdcard/${path.slice(CONTENT_TREE_PREFIX.length)}`;
+  }
+  
+  // Handle legacy emulated storage path
+  else if (path.startsWith(LEGACY_EMULATED_ROOT)) {
+    normalized = `/sdcard/${path.slice(LEGACY_EMULATED_ROOT.length)}`;
+  }
+  
+  // Passthrough
+  else {
     normalized = path;
   }
-
-  if (includeFilePrefix) {
-    return normalized.startsWith('file://') ? normalized : `file://${normalized}`;
+  
+  if (includeFilePrefix && !normalized.startsWith('file://')) {
+    return `file://${normalized}`;
   }
 
   return normalized;

--- a/packages/acode-lsp-client/src/main.js
+++ b/packages/acode-lsp-client/src/main.js
@@ -48,10 +48,23 @@ const DEFAULT_SERVER_OPTIONS = [
   }
 ];
 
-function normalizePath(path, includeFilePrefix = false) {
+function normalizePath(path, includeFilePrefix = false, useAcodeUrlTransformer = false) {
   if (!path) return '';
 
   let normalized;
+
+  if (useAcodeUrlTransformer) {
+    const acodeUrl = acode.require('Url');
+    if (!acodeUrl) return normalizePath(path, includeFilePrefix, false)
+
+    normalized = acodeUrl.pathname(path);
+
+    // Slice off `/` if there's two 🙃 ~ UnschooledGamer
+    if (normalized.startsWith('//'))
+      return normalized.slice(1);
+
+    return normalized;
+  }
 
   if (path.includes('::')) {
     const [, raw] = path.split('::');
@@ -102,7 +115,7 @@ class WorkspaceStorage {
   constructor(storageKey) {
     this.storageKey = storageKey;
   }
-  
+
   save(path, serverNames, metadata) {
     const allWorkspaces = this.load();
     allWorkspaces[path] = {
@@ -147,7 +160,7 @@ class LSPClient {
 
     this.log('Loaded', this.serverOptions.length, 'server options');
   }
-  
+
   log(...args) {
     if (!this.debug) return;
     setTimeout(() => console.log('[LSP][DEBUG]', ...args), 200);
@@ -176,7 +189,7 @@ class LSPClient {
     }
     return true;
   }
-  
+
   saveWorkspace(workspacePath, selectedServers, workspaceMetadata) {
     if (!Array.isArray(selectedServers)) selectedServers = [selectedServers];
     const serviceNames = selectedServers.map((s) => (typeof s === 'string' ? s : s.serviceName));
@@ -206,7 +219,7 @@ class LSPClient {
         savedWorkspaces
       )) {
         const folderIsOpen = openFolders.some((f) =>
-          normalizePath(f.url, true).includes(workspacePath)
+          normalizePath(f.url, true, true).includes(workspacePath)
         );
         if (!folderIsOpen) continue;
 
@@ -228,12 +241,12 @@ class LSPClient {
       this.log('Error restoring workspaces:', err);
     }
   }
-  
+
   getActiveFolderPath() {
     const fileUri = editorManager.activeFile?.uri;
     const folder = fileUri && openfolder.find(fileUri);
     if (!folder?.url) return null;
-    return normalizePath(folder.url, true);
+    return normalizePath(folder.url, true, true);
   }
 
   getCurrentFilePath() {
@@ -261,7 +274,7 @@ class LSPClient {
 
     this.log(`Editor attached to workspace: ${workspacePath}`);
   }
-  
+
   createLSPServer(workspacePath, serverOption, workspaceMetadata) {
     if (!workspacePath) return null;
 
@@ -331,7 +344,7 @@ class LSPClient {
     this.activeServers = {};
     this.log('All LSP servers shut down.');
   }
-  
+
   async promptWorkspaceSetup(defaultPath) {
     const defaultName = defaultPath.split('/').pop() || defaultPath;
     const activeServers = this.activeServers[defaultPath]
@@ -365,7 +378,7 @@ class LSPClient {
       })
     ]);
   }
-  
+
   async init() {
     this.log('Initializing LSP Plugin...');
     await this.restoreAllOpenWorkspaces();
@@ -433,7 +446,7 @@ class LSPClient {
       }
     });
   }
-  
+
   openSettingsPage() {
     const backButton = tag('span', {
       className: 'icon arrow_back',

--- a/packages/acode-lsp-client/src/main.js
+++ b/packages/acode-lsp-client/src/main.js
@@ -1,6 +1,7 @@
 import plugin from '../plugin.json';
 const page = acode.require('page');
 const alert = acode.require('alert');
+const urlModule = acode.require('Url');
 const settings = acode.require('settings');
 const openfolder = acode.require('openfolder');
 const actionStack = acode.require('actionStack');
@@ -48,66 +49,14 @@ const DEFAULT_SERVER_OPTIONS = [
   }
 ];
 
-function normalizePath(path, includeFilePrefix = false, useAcodeUrlTransformer = false) {
-  if (!path) return '';
+function normalizePath(path, includeFilePrefix = false) {
+  let normalized = urlModule.pathname(path) || '';
 
-  let normalized;
-  
-  // Define base prefixes (lengths derived automatically)
-  // Legacy internal storage ROOT
-  const LEGACY_EMULATED_ROOT = 'file:///storage/emulated/0/';
-  // Android Content External Document ROOT
-  const ANDROID_CONTENT_EXTERNAL_DOC_ROOT = 'content://com.android.externalstorage.documents';
-  const PRIMARY_PREFIX = 'primary:';
-  const CONTENT_TREE_PREFIX = 'content://com.android.externalstorage.documents/tree/primary%3A';
+  // Reduce multiple leading slashes to a single slash
+  normalized = normalized.replace(/^\/+/, '/');
 
-  if (useAcodeUrlTransformer) {
-    // Back Off for these Paths
-    if(path === LEGACY_EMULATED_ROOT || path === ANDROID_CONTENT_EXTERNAL_DOC_ROOT) {
-      return normalizePath(path, includeFilePrefix, false)
-    }
-
-    const acodeUrl = acode.require('Url');
-    if (!acodeUrl) return normalizePath(path, includeFilePrefix, false)
-
-    normalized = acodeUrl.pathname(path);
-
-    // Slice off one `/`, if there's two of them 🙃 ~ UnschooledGamer
-    if (normalized.startsWith('//'))
-      normalized = normalized.slice(1);
-
-    return normalized;
-  }
-  
-  // Handle ContentProvider secondary URI (:: separator)
-  // Gets the path after the separator, where primary means Emulated internal/primary Storage/refered as `/sdcard/`
-  
-  const colonIndex = path.indexOf('::');
-  
-  if (colonIndex !== -1) {
-    const secondaryPath = path.slice(colonIndex + 2);
-    normalized = secondaryPath.startsWith(PRIMARY_PREFIX) 
-      ? `/sdcard/${secondaryPath.slice(PRIMARY_PREFIX.length)}` 
-      : secondaryPath;
-  }
-  // Handle ContentProvider document tree URI 
-  // When there's no secondary path/file related paths
-  else if (path.startsWith(CONTENT_TREE_PREFIX)) {
-      normalized = `/sdcard/${path.slice(CONTENT_TREE_PREFIX.length)}`;
-  }
-  
-  // Handle legacy emulated storage path
-  else if (path.startsWith(LEGACY_EMULATED_ROOT)) {
-    normalized = `/sdcard/${path.slice(LEGACY_EMULATED_ROOT.length)}`;
-  }
-  
-  // Passthrough
-  else {
-    normalized = path;
-  }
-  
-  if (includeFilePrefix && !normalized.startsWith('file://')) {
-    return `file://${normalized}`;
+  if (includeFilePrefix) {
+    normalized = `file://${normalized}`;
   }
 
   return normalized;
@@ -250,7 +199,7 @@ class LSPClient {
         savedWorkspaces
       )) {
         const folderIsOpen = openFolders.some((f) =>
-          normalizePath(f.url, true, true).includes(workspacePath)
+          normalizePath(f.url, true).includes(workspacePath)
         );
         if (!folderIsOpen) continue;
 
@@ -277,7 +226,7 @@ class LSPClient {
     const fileUri = editorManager.activeFile?.uri;
     const folder = fileUri && openfolder.find(fileUri);
     if (!folder?.url) return null;
-    return normalizePath(folder.url, true, true);
+    return normalizePath(folder.url, true);
   }
 
   getCurrentFilePath() {


### PR DESCRIPTION
---

adds support for acode's url transformer in `normalizePath` function to handle
different path formats consistently across the editor environment. this improves workspace detection and file path resolution by normalizing paths
through the editor's native url utilities when available. the change adds a new parameter to `normalizePath` to optionally use acode's
Url module for proper pathname extraction, ensuring consistent workspace path handling in various file system scenarios. this fixes issues with workspace restoration and file path resolution when working with different
storage providers and path formats.
affects workspace restoration logic and active folder path detection to use the enhanced normalization for better compatibility.

---